### PR TITLE
Remove sync from hamburger menu

### DIFF
--- a/hamburger/remove-sync.css
+++ b/hamburger/remove-sync.css
@@ -1,0 +1,9 @@
+/*
+ * Remove the "Sign in to sync" from top of photon hamburger menu.
+ *
+ * Contributor(s): PilzAdam
+ */
+
+#appMenu-fxa-container, #appMenu-fxa-container + toolbarseparator {
+	display: none !important;
+}


### PR DESCRIPTION
Remove the "Sign in to sync" entry at the top of the photon hamburger menu. It's just really annoying when not using sync. Also removes the separator below it.