### PR TITLE
Remove 'send page to device' from context menu

### DIFF
--- a/context-menu/remove-send-to-device.css
+++ b/context-menu/remove-send-to-device.css
@@ -1,0 +1,9 @@
+/*
+ * Remove "Send Page to Device" from context menu.
+ *
+ * Contributor(s): PilzAdam
+ */
+
+#context-sendpagetodevice, #context-sep-sendpagetodevice {
+  display: none !important;
+}


### PR DESCRIPTION
My quest to banish sync from annoying places continues.

This rule removes the "send page to device" entry from the context menu. I have only tested this on nightly; I don't know if this entry even exists on current stable.