### PR TITLE
Create vertical-context-navigation.css

### DIFF
--- a/context-menu/vertical-context-navigation-Windows.css
+++ b/context-menu/vertical-context-navigation-Windows.css
@@ -18,25 +18,14 @@
   position:absolute !important;
 }
 
-/*
-* These rules fix layout incompatibility between Linux and Windows
-* The padding cannot be modified on Linux so set padding on all platforms to 4px
-* and create a negative margin to counter it.
-* Small issue is that back-button height on Windows is 4px smaller than others
-*/
-#contentAreaContextMenu #context-navigation:not([hidden]) menuitem{
-  margin:-4px 0;
-  padding: 2px 4px 3px 4px;
-}
-
 /* Move all context-menu entries right except the navigation items */ 
-#contentAreaContextMenu #context-navigation:not([hidden])~*{
-  margin-left: 38px !important;
+#contentAreaContextMenu #context-navigation:not([hidden]) ~ *{
+  margin-left: 30px !important;
 }
 
 /* Hardcode the elements' heights in case they are different on some platforms */
-#contentAreaContextMenu #context-navigation:not([hidden])~menu,
-#contentAreaContextMenu #context-navigation:not([hidden])~menuitem{
+#contentAreaContextMenu #context-navigation:not([hidden]) ~ menu,
+#contentAreaContextMenu #context-navigation:not([hidden]) ~ menuitem{
   min-height:24px !important;
   height:24px !important;
 }
@@ -45,28 +34,27 @@
 #context-sep-navigation{
   display:none;
 }
-/*
-* Move text leftwards.
-* Hardcoding padding-inline-start fixes different text positioning between Windows and Linux
-*/
-#contentAreaContextMenu #context-navigation:not([hidden])~menuitem .menu-text,
-#contentAreaContextMenu #context-navigation:not([hidden])~menu .menu-text{
+/* Move only text leftwards - not the whole elements */
+#contentAreaContextMenu #context-navigation:not([hidden]) ~ menuitem > .menu-text,
+#contentAreaContextMenu #context-navigation:not([hidden]) ~ menu > .menu-text{
   margin-left: -20px !important;
-  padding-inline-start: 30px !important;
 }
 
 /* Move menuitems up. Will fail if save-page item is for some reason not the topmost */
-#contentAreaContextMenu #context-navigation:not([hidden])~#context-savepage,
-#contentAreaContextMenu #context-navigation:not([hidden])~#context-sep-navigation+menuitem[generateditemid]{
+#contentAreaContextMenu #context-navigation:not([hidden]) ~ #context-savepage,
+#contentAreaContextMenu #context-navigation:not([hidden]) ~ #context-sep-navigation + menuitem[generateditemid]{
   margin-top: -128px !important;
 }
 
 /* There can be generated menuitems such as Edit-page that appears on MDN so need to handle them */
-#contentAreaContextMenu #context-navigation:not([hidden])~menuitem[generateditemid]~#context-savepage{
+#contentAreaContextMenu #context-navigation:not([hidden]) ~ menuitem[generateditemid] ~ #context-savepage{
   margin-top: unset !important;
 }
 
-/* It's hard to explain why this is necessary, it has to do with how context menu height is calculated */
+/*
+* This is needed because it is necessary to adjust the bottom * margin of last ENABLED element. So create a pseudo-element 
+* which will always be last and set it's margin.
+*/
 #contentAreaContextMenu .scrollbox-innerbox::after{ 
   content: "";
   position: absolute;
@@ -80,7 +68,7 @@
 }
 
 /* Get rid of the margin when navigation buttons are disabled. Watching collapsed attribute of autorepeatbutton is only way to track such case */
-#contentAreaContextMenu autorepeatbutton[collapsed]~.arrowscrollbox-scrollbox .scrollbox-innerbox::after{
+#contentAreaContextMenu autorepeatbutton[collapsed] ~ .arrowscrollbox-scrollbox .scrollbox-innerbox::after{
   display:none;
 }
 
@@ -93,3 +81,11 @@
 #contentAreaContextMenu .scrollbox-innerbox{
   overflow: hidden;
 }
+/* Effectively remove vertical separator line on Windows7 */
+@media (-moz-os-version: windows-win7){
+  #contentAreaContextMenu{
+    -moz-appearance:none !important;
+    border: 1px solid darkgrey !important;
+  }
+}
+

--- a/context-menu/vertical-context-navigation.css
+++ b/context-menu/vertical-context-navigation.css
@@ -16,12 +16,22 @@
 #contentAreaContextMenu #context-navigation:not([hidden]) menuitem{
   pointer-events: auto !important;
   position:absolute !important;
-  margin-left:0px;
+}
+
+/*
+* These rules fix layout incompatibility between Linux and Windows
+* The padding cannot be modified on Linux so set padding on all platforms to 4px
+* and create a negative margin to counter it.
+* Small issue is that back-button height on Windows is 4px smaller than others
+*/
+#contentAreaContextMenu #context-navigation:not([hidden]) menuitem{
+  margin:-4px 0;
+  padding: 2px 4px 3px 4px;
 }
 
 /* Move all context-menu entries right except the navigation items */ 
 #contentAreaContextMenu #context-navigation:not([hidden])~*{
-  margin-left: 30px !important;
+  margin-left: 38px !important;
 }
 
 /* Hardcode the elements' heights in case they are different on some platforms */
@@ -31,25 +41,18 @@
   height:24px !important;
 }
 
-/*
-* Set icon margin to 7px. Bigger values effectively move other menuitems down and make buttons bigger.
-* There's a chance that this won't correct the layout on Linux or might need a browser restart
-* because some margins appear to be defined through margin-inline- properties which don't seem to get
-* reloaded through browser toolbox.
-*/
-#context-navigation > .menuitem-iconic > .menu-iconic-left > .menu-iconic-icon{
-  margin:7px !important;
-}
-
 /* Get rid of now unimportant separator */
 #context-sep-navigation{
   display:none;
 }
-
-/* Move text leftwards */
+/*
+* Move text leftwards.
+* Hardcoding padding-inline-start fixes different text positioning between Windows and Linux
+*/
 #contentAreaContextMenu #context-navigation:not([hidden])~menuitem .menu-text,
 #contentAreaContextMenu #context-navigation:not([hidden])~menu .menu-text{
   margin-left: -20px !important;
+  padding-inline-start: 30px !important;
 }
 
 /* Move menuitems up. Will fail if save-page item is for some reason not the topmost */

--- a/context-menu/vertical-context-navigation.css
+++ b/context-menu/vertical-context-navigation.css
@@ -1,32 +1,44 @@
-@namespace url(http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul);
+/*
+ * Make the context-menu navigation items vertical
+ *
+ * Contributor(s): MrOtherGuy
+ */
 
-/* This is hacky solution but the context menu structure makes it hard to position things correctly */
-
-/* Set the navigation container vertical and disable the containers pointer events.*/
+/* Set the container vertical and disable the its pointer events */
 #contentAreaContextMenu #context-navigation:not([hidden]){ 
   -moz-box-orient: vertical !important;
   position:absolute !important;
   background-color: transparent !important;
   pointer-events: none;
 }
-/* Enable individual buttons' pointer-events which would be disabled through cascade*/
+
+/* Enable individual buttons' pointer-events which would otherwise be disabled through cascade */
 #contentAreaContextMenu #context-navigation:not([hidden]) menuitem{
   pointer-events: auto !important;
   position:absolute !important;
   margin-left:0px;
 }
 
-/* #contentAreaContextMenu #context-navigation:not([hidden])~* should work too :p */
-#contentAreaContextMenu #context-navigation:not([hidden])~menuitem,
-#contentAreaContextMenu #context-navigation:not([hidden])~menu,
-#contentAreaContextMenu #context-navigation:not([hidden])~menuseparator{
-  margin-left: 30px;
+/* Move all context-menu entries right except the navigation items */ 
+#contentAreaContextMenu #context-navigation:not([hidden])~*{
+  margin-left: 30px !important;
 }
 
-/* Not totally sure how necessary this is, but just to be safe */
-#contentAreaContextMenu menuitem:not([class="menuitem-iconic"]){
+/* Hardcode the elements' heights in case they are different on some platforms */
+#contentAreaContextMenu #context-navigation:not([hidden])~menu,
+#contentAreaContextMenu #context-navigation:not([hidden])~menuitem{
   min-height:24px !important;
-  height:24px;
+  height:24px !important;
+}
+
+/*
+* Set icon margin to 7px. Bigger values effectively move other menuitems down and make buttons bigger.
+* There's a chance that this won't correct the layout on Linux or might need a browser restart
+* because some margins appear to be defined through margin-inline- properties which don't seem to get
+* reloaded through browser toolbox.
+*/
+#context-navigation > .menuitem-iconic > .menu-iconic-left > .menu-iconic-icon{
+  margin:7px !important;
 }
 
 /* Get rid of now unimportant separator */
@@ -40,7 +52,7 @@
   margin-left: -20px !important;
 }
 
-/* Move menuitems up. Will fail if save-page item is for some reason not the topmoset*/
+/* Move menuitems up. Will fail if save-page item is for some reason not the topmost */
 #contentAreaContextMenu #context-navigation:not([hidden])~#context-savepage,
 #contentAreaContextMenu #context-navigation:not([hidden])~#context-sep-navigation+menuitem[generateditemid]{
   margin-top: -128px !important;
@@ -64,17 +76,17 @@
   display:none;
 }
 
-/* Get rid of the margin when navigation buttons are disabled. autorepeatbutton[collapsed] is only way to track such case*/
+/* Get rid of the margin when navigation buttons are disabled. Watching collapsed attribute of autorepeatbutton is only way to track such case */
 #contentAreaContextMenu autorepeatbutton[collapsed]~.arrowscrollbox-scrollbox .scrollbox-innerbox::after{
   display:none;
 }
 
-/* Also disable the margin on sub-menus unconditionally*/
+/* Also disable the margin on sub-menus unconditionally */
 #contentAreaContextMenu menupopup .scrollbox-innerbox::after{ 
   display: none;
 }
 
-/* You could scroll the menu without this - safe to remove if that's not a problem*/
+/* You could scroll the menu without this - safe to remove if that's not a problem */
 #contentAreaContextMenu .scrollbox-innerbox{
   overflow: hidden;
 }

--- a/context-menu/vertical-context-navigation.css
+++ b/context-menu/vertical-context-navigation.css
@@ -1,0 +1,80 @@
+@namespace url(http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul);
+
+/* This is hacky solution but the context menu structure makes it hard to position things correctly */
+
+/* Set the navigation container vertical and disable the containers pointer events.*/
+#contentAreaContextMenu #context-navigation:not([hidden]){ 
+  -moz-box-orient: vertical !important;
+  position:absolute !important;
+  background-color: transparent !important;
+  pointer-events: none;
+}
+/* Enable individual buttons' pointer-events which would be disabled through cascade*/
+#contentAreaContextMenu #context-navigation:not([hidden]) menuitem{
+  pointer-events: auto !important;
+  position:absolute !important;
+  margin-left:0px;
+}
+
+/* #contentAreaContextMenu #context-navigation:not([hidden])~* should work too :p */
+#contentAreaContextMenu #context-navigation:not([hidden])~menuitem,
+#contentAreaContextMenu #context-navigation:not([hidden])~menu,
+#contentAreaContextMenu #context-navigation:not([hidden])~menuseparator{
+  margin-left: 30px;
+}
+
+/* Not totally sure how necessary this is, but just to be safe */
+#contentAreaContextMenu menuitem:not([class="menuitem-iconic"]){
+  min-height:24px !important;
+  height:24px;
+}
+
+/* Get rid of now unimportant separator */
+#context-sep-navigation{
+  display:none;
+}
+
+/* Move text leftwards */
+#contentAreaContextMenu #context-navigation:not([hidden])~menuitem .menu-text,
+#contentAreaContextMenu #context-navigation:not([hidden])~menu .menu-text{
+  margin-left: -20px !important;
+}
+
+/* Move menuitems up. Will fail if save-page item is for some reason not the topmoset*/
+#contentAreaContextMenu #context-navigation:not([hidden])~#context-savepage,
+#contentAreaContextMenu #context-navigation:not([hidden])~#context-sep-navigation+menuitem[generateditemid]{
+  margin-top: -128px !important;
+}
+
+/* There can be generated menuitems such as Edit-page that appears on MDN so need to handle them */
+#contentAreaContextMenu #context-navigation:not([hidden])~menuitem[generateditemid]~#context-savepage{
+  margin-top: unset !important;
+}
+
+/* It's hard to explain why this is necessary, it has to do with how context menu height is calculated */
+#contentAreaContextMenu .scrollbox-innerbox::after{ 
+  content: "";
+  position: absolute;
+  margin-bottom:106px;
+  visibility: hidden;
+}
+
+/* At this point there's a rather big bottom margin which then causes overflow buttons to appear */
+#contentAreaContextMenu autorepeatbutton{
+  display:none;
+}
+
+/* Get rid of the margin when navigation buttons are disabled. autorepeatbutton[collapsed] is only way to track such case*/
+#contentAreaContextMenu autorepeatbutton[collapsed]~.arrowscrollbox-scrollbox .scrollbox-innerbox::after{
+  display:none;
+}
+
+/* Also disable the margin on sub-menus unconditionally*/
+#contentAreaContextMenu menupopup .scrollbox-innerbox::after{ 
+  display: none;
+}
+
+/* You could scroll the menu without this - safe to remove if that's not a problem*/
+#contentAreaContextMenu .scrollbox-innerbox{
+  overflow: hidden;
+}


### PR DESCRIPTION
Modifies context menu to place context-navigation buttons vertically.
Not the cleanest code and might not work with all extensions or OS. Only Win10 tested.
Also, hoping I'm doing this right.. Haven't really used github before