### PR TITLE
Update remove-back-button-circle.css

### DIFF
--- a/navbar/remove-back-button-circle.css
+++ b/navbar/remove-back-button-circle.css
@@ -9,6 +9,7 @@
   border: unset !important;
   padding: var(--toolbarbutton-inner-padding) !important;
   border-radius: var(--toolbarbutton-border-radius) !important;
+  width: calc(2 * var(--toolbarbutton-inner-padding) + 16px) !important;
 }
 
 /* Hover and Active states to mimic other buttons */


### PR DESCRIPTION
New Nightly update made back button bigger. This will enforce the size of other toolbar buttons.