### PR TITLE
Bookmarks displayed on toolbars appear as favicons

### DIFF
--- a/toolbars/faviconized-bookmarks.css
+++ b/toolbars/faviconized-bookmarks.css
@@ -1,0 +1,13 @@
+// When bookmarks are displayed on a toolbar, they appear as favicons. (Text is hidden)
+// Screenshot: https://s26.postimg.org/lnb9akmbd/Faviconized-bookmarks.png
+// Tested on Firefox 55, Windows 7
+
+// Hides bookmark text when they are displayed on a toolbar
+.bookmark-item > .toolbarbutton-text {
+		display: none !important;
+}
+
+// Small visual tweak so it looks exactly the same as if the bookmark really had no text
+.bookmark-item > .toolbarbutton-icon	{
+		margin-inline-end: 0px !important;
+}

--- a/toolbars/faviconized-bookmarks.css
+++ b/toolbars/faviconized-bookmarks.css
@@ -1,13 +1,17 @@
-// When bookmarks are displayed on a toolbar, they appear as favicons. (Text is hidden)
-// Screenshot: https://s26.postimg.org/lnb9akmbd/Faviconized-bookmarks.png
-// Tested on Firefox 55, Windows 7
+/*
+  When bookmarks are displayed on a toolbar, they appear as favicons. (Text is hidden)
+  
+  Screenshot: https://s26.postimg.org/lnb9akmbd/Faviconized-bookmarks.png
+  
+  Tested on Firefox 55, Windows 7
+*/
 
-// Hides bookmark text when they are displayed on a toolbar
+/** Hides bookmark text when they are displayed on a toolbar */
 .bookmark-item > .toolbarbutton-text {
 		display: none !important;
 }
 
-// Small visual tweak so it looks exactly the same as if the bookmark really had no text
+/** Small visual tweak so it looks exactly the same as if the bookmark really had no text */
 .bookmark-item > .toolbarbutton-icon	{
 		margin-inline-end: 0px !important;
 }

--- a/toolbars/faviconized-bookmarks.css
+++ b/toolbars/faviconized-bookmarks.css
@@ -6,7 +6,7 @@
   Tested on Firefox 55, Windows 7
 */
 
-/** Hides bookmark text when they are displayed on a toolbar */
+/** Hides bookmark text for all bookmarks displayed in a toolbar */
 .bookmark-item > .toolbarbutton-text  {
   display: none !important;
 }

--- a/toolbars/faviconized-bookmarks.css
+++ b/toolbars/faviconized-bookmarks.css
@@ -7,11 +7,11 @@
 */
 
 /** Hides bookmark text when they are displayed on a toolbar */
-.bookmark-item > .toolbarbutton-text {
-		display: none !important;
+.bookmark-item > .toolbarbutton-text  {
+  display: none !important;
 }
 
 /** Small visual tweak so it looks exactly the same as if the bookmark really had no text */
-.bookmark-item > .toolbarbutton-icon	{
-		margin-inline-end: 0px !important;
+.bookmark-item > .toolbarbutton-icon  {
+  margin-inline-end: 0px !important;
 }

--- a/toolbars/faviconized-bookmarks.css
+++ b/toolbars/faviconized-bookmarks.css
@@ -1,17 +1,18 @@
 /*
-  When bookmarks are displayed on a toolbar, they appear as favicons. (Text is hidden)
-  
-  Screenshot: https://s26.postimg.org/lnb9akmbd/Faviconized-bookmarks.png
-  
-  Tested on Firefox 55, Windows 7
-*/
+ * When bookmarks are displayed on a toolbar, they appear as favicons. (Text is hidden)
+ * 
+ * Screenshot: https://s26.postimg.org/lnb9akmbd/Faviconized-bookmarks.png
+ * 
+ * Tested on Firefox 55, Windows 7
+ * Contributor(s): Okamoi
+ */
 
-/** Hides bookmark text for all bookmarks displayed in a toolbar */
+/* Hides bookmark text for all bookmarks displayed in a toolbar */
 .bookmark-item > .toolbarbutton-text  {
   display: none !important;
 }
 
-/** Small visual tweak so it looks exactly the same as if the bookmark really had no text */
+/* Small visual tweak so it looks exactly the same as if the bookmark really had no text */
 .bookmark-item > .toolbarbutton-icon  {
   margin-inline-end: 0px !important;
 }


### PR DESCRIPTION
With this CSS, bookmarks displayed on a toolbar appear as favicons. Text is hidden as per [screenshot](https://s26.postimg.org/lnb9akmbd/Faviconized-bookmarks.png).

This is a Classic Theme Restorer feature, or so I hear.