### PR TITLE
Hide puzzle icon on add-on pages

### DIFF
--- a/navbar/hide-puzzle-on-addon-pages.css
+++ b/navbar/hide-puzzle-on-addon-pages.css
@@ -1,0 +1,9 @@
+/*
+ * Hide the puzzle icon indicating an extension page from the location bar
+ *
+ * Contributor(s): Madis0
+ */
+ 
+#urlbar[pageproxystate="valid"] > #identity-box.extensionPage > #extension-icon {
+  display: none !important;
+}


### PR DESCRIPTION
Hides the puzzle icons on WE add-on internal pages (moz-extension://whatever).