### PR TITLE
Fix move-identity-lock-right.css for Photon

### DIFF
--- a/navbar/move-identity-lock-right.css
+++ b/navbar/move-identity-lock-right.css
@@ -1,17 +1,27 @@
 /*
- * Move the identity icon and SSL lock to the right of the location bar
+ * Move the identity icon and SSL lock to the end of the address bar, 
+ * move/adjust the 3-dot page action button to make it look better
  *
- * Contributor(s): Madis0, reddit user BatDogOnBatMobile
+ * Contributor(s): Madis0
  */
 
 #urlbar > #identity-box
 {
-  -moz-box-ordinal-group: 2 !important; /* Move identity box to the right */
+  -moz-box-ordinal-group: 99 !important; /* Move identity box to the end */
+  border-inline-end: none !important; /* Remove any right borders from it (internal pages, EV SSL) */
+  margin-inline-end: 0em !important; /* Remove the end margin */
+  margin-inline-start: -0.2em !important; /* Remove the start margin */
 }
 
-#urlbar > #page-action-buttons
-{
-  -moz-box-ordinal-group: 3 !important; /* Move page action buttons more to the right, to keep identity box on the left of them */
+#urlbar > #page-action-buttons > #pageActionButton {
+  -moz-box-ordinal-group: 99 !important; /* Move the 3-dot page action button to the rightmost of page action icons */
+  border-inline-end: 1px solid var(--urlbar-separator-color); /* Add a permanent border (separator) to the right of it */
+  border-image: linear-gradient(transparent 15%, var(--urlbar-separator-color) 15%, var(--urlbar-separator-color) 85%, transparent 85%); /* Separator properties like original */
+  border-image-slice: 1; /* Don't make it full-height */
+}
+
+#pageActionSeparator {
+    visibility: hidden !important; /* Hide the original separator */
 }
 
 .urlbar-input-box
@@ -19,10 +29,3 @@
   margin-left: 0.5em !important; /* Add some margin back to left of urlbar to make it prettier */
 }
 
-/* Fix autocomplete item display */
-#PopupAutoCompleteRichResult .ac-site-icon,
-#PopupAutoCompleteRichResult .ac-type-icon 
-{
-  margin-left: 300em !important;
-  margin-right: -294em !important;
-}

--- a/navbar/move-identity-lock-right.css
+++ b/navbar/move-identity-lock-right.css
@@ -4,23 +4,28 @@
  * Contributor(s): Madis0
  */
 
-#identity-box
+#urlbar > #identity-box
 {
-  -moz-box-ordinal-group: 5 !important;
+  -moz-box-ordinal-group: 2 !important; /* Move identity box to the right */
 }
 
-.urlbar-input
+.urlbar-input-box
 {
-  margin-left: 0.3em !important;
+  margin-left: 0.5em !important; /* Add some margin back to left of urlbar to make it prettier */
 }
 
-#PopupAutoCompleteRichResult .ac-site-icon
-{
-  margin-left: 10px !important;
-  margin-right: 10px !important;
+#urlbar[pageproxystate="valid"] > #identity-box.verifiedIdentity,
+#urlbar[pageproxystate="valid"] > #identity-box.chromeUI, 
+#urlbar[pageproxystate="valid"] > #identity-box.extensionPage, 
+#urlbar-display-box {
+  margin-inline-end: 0em !important; /* Remove the margin at the end for EV SSL, addons, internal */
+  border-inline-end: none !important; /* Remove the border at the end EV SSL, addons, internal */
 }
 
-#PopupAutoCompleteRichResult .ac-type-icon
+/* Fix autocomplete item display */
+#PopupAutoCompleteRichResult .ac-site-icon,
+#PopupAutoCompleteRichResult .ac-type-icon 
 {
-  margin-left: 10px !important;
+  margin-left: 300em !important;
+  margin-right: -294em !important;
 }

--- a/navbar/move-identity-lock-right.css
+++ b/navbar/move-identity-lock-right.css
@@ -15,17 +15,9 @@
 
 #urlbar > #page-action-buttons > #pageActionButton {
   -moz-box-ordinal-group: 99 !important; /* Move the 3-dot page action button to the rightmost of page action icons */
-  border-inline-end: 1px solid var(--urlbar-separator-color); /* Add a permanent border (separator) to the right of it */
-  border-image: linear-gradient(transparent 15%, var(--urlbar-separator-color) 15%, var(--urlbar-separator-color) 85%, transparent 85%); /* Separator properties like original */
-  border-image-slice: 1; /* Don't make it full-height */
-}
-
-#pageActionSeparator {
-    display: none !important; /* Hide the original separator */
 }
 
 .urlbar-input-box
 {
   margin-left: 0.5em !important; /* Add some margin back to left of urlbar to make it prettier */
 }
-

--- a/navbar/move-identity-lock-right.css
+++ b/navbar/move-identity-lock-right.css
@@ -1,7 +1,7 @@
 /*
  * Move the identity icon and SSL lock to the right of the location bar
  *
- * Contributor(s): Madis0
+ * Contributor(s): Madis0, reddit user BatDogOnBatMobile
  */
 
 #urlbar > #identity-box
@@ -9,17 +9,14 @@
   -moz-box-ordinal-group: 2 !important; /* Move identity box to the right */
 }
 
+#urlbar > #page-action-buttons
+{
+  -moz-box-ordinal-group: 3 !important; /* Move page action buttons more to the right, to keep identity box on the left of them */
+}
+
 .urlbar-input-box
 {
   margin-left: 0.5em !important; /* Add some margin back to left of urlbar to make it prettier */
-}
-
-#urlbar[pageproxystate="valid"] > #identity-box.verifiedIdentity,
-#urlbar[pageproxystate="valid"] > #identity-box.chromeUI, 
-#urlbar[pageproxystate="valid"] > #identity-box.extensionPage, 
-#urlbar-display-box {
-  margin-inline-end: 0em !important; /* Remove the margin at the end for EV SSL, addons, internal */
-  border-inline-end: none !important; /* Remove the border at the end EV SSL, addons, internal */
 }
 
 /* Fix autocomplete item display */

--- a/navbar/move-identity-lock-right.css
+++ b/navbar/move-identity-lock-right.css
@@ -21,7 +21,7 @@
 }
 
 #pageActionSeparator {
-    visibility: hidden !important; /* Hide the original separator */
+    display: none !important; /* Hide the original separator */
 }
 
 .urlbar-input-box

--- a/navbar/move-identity-lock-right.css
+++ b/navbar/move-identity-lock-right.css
@@ -20,4 +20,4 @@
 .urlbar-input-box
 {
   margin-left: 0.5em !important; /* Add some margin back to left of urlbar to make it prettier */
-}
+} /* If you're using reload-button-addressbar-left.css, set the value to 2em. */


### PR DESCRIPTION
Fixed the style to look right on latest Nightly, also added inline comments to code.
You can keep the original in a separate branch (FX 56) I guess, but I won't help maintain it as I only want my Photon-supported styles here.