### PR TITLE
New tweak: hide sidebar header

### DIFF
--- a/sidebar/hide-header.css
+++ b/sidebar/hide-header.css
@@ -1,0 +1,14 @@
+/*
+ * Description: hide the header of the sidebar, which takes quite a bit of space.
+ * Use with caution: you will no longer have a way to switch between sidebar panes,
+ * so make sure you have some other way of doing so if you need to.
+ * (For example, an extension can add a toolbar button which opens its sidebar pane.)
+ *
+ * Screenshot: sorry, I’m lazy.
+ *
+ * Contributor(s): Chris Morgan
+ */
+
+#sidebar-header {
+  display: none;
+}


### PR DESCRIPTION
If you want a permanent sidebar pane (such as a vertical tabs extension),
it can be nice to get rid of the wasted vertical space of the sidebar header.