### PR TITLE
 Move the tab bar to bottom of the window (MacOS)

### DIFF
--- a/toolbars/bottom-of-window-tabbar-macOS.css
+++ b/toolbars/bottom-of-window-tabbar-macOS.css
@@ -1,0 +1,29 @@
+/*
+ * Description: Moves the tab bar down the window. Only for Mac.
+ * 
+ * Screenshot:
+ * 
+ * Tested on Mac
+ *
+ * Contributor(s): Reddit's /u/marciiF
+ * Licenced GPLv3
+ */
+ 
+ 
+ @-moz-document url("chrome://browser/content/browser.xul") {
+    :root:not([tabsintitlebar]) #TabsToolbar {
+        transform: translateY(100vh) !important;
+    }
+    :root:not([tabsintitlebar]) #navigator-toolbox {
+        margin-top: calc(0px - var(--tab-min-height)) !important;
+    }
+    :root:not([tabsintitlebar]) #browser-panel {
+        padding-bottom: var(--tab-min-height) !important;
+    }
+
+    :root:not([tabsintitlebar]) #TabsToolbar              { -moz-box-ordinal-group: 0 !important; }
+    :root:not([tabsintitlebar]) #toolbar-menubar          { -moz-box-ordinal-group: 1 !important; }
+    :root:not([tabsintitlebar]) #nav-bar                  { -moz-box-ordinal-group: 2 !important; }
+    :root:not([tabsintitlebar]) #PersonalToolbar          { -moz-box-ordinal-group: 3 !important; }
+    :root:not([tabsintitlebar]) #navigator-toolbox::after { -moz-box-ordinal-group: 4 !important; }
+}


### PR DESCRIPTION
Code posted [here](https://www.reddit.com/r/FirefoxCSS/comments/6xyyy5/request_tabs_on_the_bottom_of_the_entire_firefox/dmjiamm/) on /r/FirefoxCSS, licensed GPLv3 by author and tested by him and one other person. I don't know which Firefox UI they tried it on, Photon, Australis, both ?

There may be a couple full screen bugs, see [this](https://github.com/Timvde/UserChrome-Tweaks/pull/33) pull request which is the same CSS but for Windows 7.