### PR TITLE
autohide-info-icon.css: fix the spacing on hover

### DIFF
--- a/navbar/autohide-info-icon.css
+++ b/navbar/autohide-info-icon.css
@@ -16,5 +16,5 @@
 #navigator-toolbox:hover #urlbar[pageproxystate="valid"] #identity-icon {
         transition: 300ms !important; /* Animate icon showing */
 	opacity: 1 !important; /* Make icons opaque */
-	-moz-margin-end: inherit !important; /* Use initial margins to show icons */
+	-moz-margin-end: initial !important; /* Use initial margins to show icons */
 }

--- a/navbar/autohide-info-icon.css
+++ b/navbar/autohide-info-icon.css
@@ -13,7 +13,7 @@
 }
 
 /* Show info icon on navbar hover, except for new tab page search icon */
-#navigator-toolbox:hover #urlbar[pageproxystate="valid"] #identity-icon {
+#urlbar[pageproxystate="valid"]:hover #identity-icon {
         transition: 300ms !important; /* Animate icon showing */
 	opacity: 1 !important; /* Make icons opaque */
 	-moz-margin-end: initial !important; /* Use initial margins to show icons */

--- a/navbar/autohide-info-icon.css
+++ b/navbar/autohide-info-icon.css
@@ -12,8 +12,8 @@
 	-moz-margin-end: -1.1em !important; /* Hide icons by offsetting them */
 }
 
-/* Show info icon on hover, except for new tab page */
-#urlbar[pageproxystate="valid"]:hover #identity-icon {
+/* Show info icon on navbar hover, except for new tab page search icon */
+#navigator-toolbox:hover #urlbar[pageproxystate="valid"] #identity-icon {
         transition: 300ms !important; /* Animate icon showing */
 	opacity: 1 !important; /* Make icons opaque */
 	-moz-margin-end: inherit !important; /* Use initial margins to show icons */


### PR DESCRIPTION
~Makes the info icon show on navbar hover, so it appears together with the dropdown icon.~

Fixed the spacing on hover, small comment change.