### PR TITLE
Fix no-page-action-button.css

### DIFF
--- a/navbar/no-page-action-button.css
+++ b/navbar/no-page-action-button.css
@@ -9,8 +9,3 @@
 #pageActionButton {
   display: none !important;
 }
-
-#page-action-buttons {
-  display: none !important;
-}
-

--- a/navbar/no-page-action-button.css
+++ b/navbar/no-page-action-button.css
@@ -3,7 +3,7 @@
  * urlbar which gives you options such as: "Bookmark this page", "Save page to
  * pocket", etc.
  *
- * Contributor(s): DrPugsley
+ * Contributor(s): DrPugsley, Madis0
  */
 
 #pageActionButton {


### PR DESCRIPTION
The `#page-action-buttons` piece also removed other elements from the address bar, including extension icons, reader mode, Containers icon, therefore removing it.