### PR TITLE
Remove padding when not maximized (on restore/windowed mode) - Windows only!

### DIFF
--- a/tabs/remove-padding-when-not-maximized-Windows.css
+++ b/tabs/remove-padding-when-not-maximized-Windows.css
@@ -1,11 +1,11 @@
 /*
  * Description: Removes the space while on windowed ("restored") mode. Windows only.
  *
- * Screenshot: (wait)
+ * Screenshot: https://imgur.com/a/uKX3X
  *
  * Contributor(s): Gacel Perfinian
  *
- * License: Any of the following: CC-BY, GPL (any version release by FSF), MIT, MPLv2.
+ * License: Any of the following licences: CC-BY, GPL (any version released by FSF), MIT, MPLv2.
  */
 
 .titlebar-placeholder[type="pre-tabs"], .titlebar-placeholder[type="post-tabs"] {

--- a/tabs/remove-padding-when-not-maximized-Windows.css
+++ b/tabs/remove-padding-when-not-maximized-Windows.css
@@ -1,0 +1,13 @@
+/*
+ * Description: Removes the space while on windowed ("restored") mode. Windows only.
+ *
+ * Screenshot: (wait)
+ *
+ * Contributor(s): Gacel Perfinian
+ *
+ * License: Any of the following: CC-BY, GPL (any version release by FSF), MIT, MPLv2.
+ */
+
+.titlebar-placeholder[type="pre-tabs"], .titlebar-placeholder[type="post-tabs"] {
+  display:none !important;
+}

--- a/tabs/remove-padding-when-not-maximized.css
+++ b/tabs/remove-padding-when-not-maximized.css
@@ -1,6 +1,0 @@
-/* This userChrome Hack is only tested on Winodws
-   CC-BY, Gacel Perfinian */
-
-.titlebar-placeholder[type="pre-tabs"], .titlebar-placeholder[type="post-tabs"] {
-  display:none !important;
-}

--- a/tabs/remove-padding-when-not-maximized.css
+++ b/tabs/remove-padding-when-not-maximized.css
@@ -1,0 +1,6 @@
+/* This userChrome Hack is only tested on Winodws
+   CC-BY, Gacel Perfinian */
+
+.titlebar-placeholder[type="pre-tabs"], .titlebar-placeholder[type="post-tabs"] {
+  display:none !important;
+}


### PR DESCRIPTION
Remove those spaces while the window is not maximized. Only works on Windows, doesn't remove the space to the top.