### PR TITLE
Make uBlock Origin element picker show regions

### DIFF
--- a/activitystream/activitystream-dark-userContent.css
+++ b/activitystream/activitystream-dark-userContent.css
@@ -12,7 +12,7 @@
   }
 }
 @-moz-document url("about:blank") {
-  body {
+  *:empty:not([id]):not([style]) {
     background-color: #474749 !important;
   }
 }


### PR DESCRIPTION
This edit allows you to see the uBlock Origin element picker [regions](https://i.imgur.com/SKCfnT4.png) instead of a completely black [background.](https://i.imgur.com/6wNHtZT.png)