### PR TITLE
Autohide "Reload in address bar"

### DIFF
--- a/extensions/autohide-reload-in-address-bar.css
+++ b/extensions/autohide-reload-in-address-bar.css
@@ -12,7 +12,7 @@
         -moz-margin-end: -1.1em !important; /* Hide icon by offsetting it */
 }
 
-/* Show the reload button on navbar hover */
+/* Show the reload button on address bar hover */
 #urlbar:hover .webextension-page-action[id="_e1ed7a80-7c11-4f7e-968b-79b551a0067f_-page-action"] {
         transition: 300ms !important; /* Animate icon showing */
         opacity: 1 !important; /* Make the icon opaque */

--- a/extensions/autohide-reload-in-address-bar.css
+++ b/extensions/autohide-reload-in-address-bar.css
@@ -1,0 +1,20 @@
+/*
+ * Automatically hides the reload button created by 
+ * https://addons.mozilla.org/en-US/firefox/addon/reload-in-address-bar/
+ *
+ * Contributor(s): Madis0
+ */
+
+/* Hide the extension's reload button by default */
+#urlbar .webextension-page-action[id="_e1ed7a80-7c11-4f7e-968b-79b551a0067f_-page-action"] {
+        transition: 300ms !important; /* Animate icon hiding */
+        opacity: 0 !important; /* Make icon transparent */
+        -moz-margin-end: -1.1em !important; /* Hide icon by offsetting it */
+}
+
+/* Show the reload button on navbar hover */
+#urlbar:hover .webextension-page-action[id="_e1ed7a80-7c11-4f7e-968b-79b551a0067f_-page-action"] {
+        transition: 300ms !important; /* Animate icon showing */
+        opacity: 1 !important; /* Make the icon opaque */
+        -moz-margin-end: initial !important; /* Use initial margins to show the icon */
+}

--- a/extensions/autohide-reload-in-address-bar.css
+++ b/extensions/autohide-reload-in-address-bar.css
@@ -1,19 +1,25 @@
 /*
- * Automatically hides the reload button created by 
+ * Automatically hides the reload button created by any of these extensions:
  * https://addons.mozilla.org/en-US/firefox/addon/reload-in-address-bar/
+ * https://addons.mozilla.org/en-US/firefox/addon/australis-refresh-in-url-bar/
+ * https://addons.mozilla.org/en-US/firefox/addon/reload-in-urlbar/
  *
  * Contributor(s): Madis0
  */
 
 /* Hide the extension's reload button by default */
-#urlbar .webextension-page-action[id="_e1ed7a80-7c11-4f7e-968b-79b551a0067f_-page-action"] {
+#urlbar .webextension-page-action[id="_e1ed7a80-7c11-4f7e-968b-79b551a0067f_-page-action"], 
+#urlbar .webextension-page-action[id="_7afe2ae8-0244-48d6-8007-6aadad9a6090_-page-action"], 
+#urlbar .webextension-page-action[id="reload-in-urlbar_exe-boss-page-action"] {
         transition: 300ms !important; /* Animate icon hiding */
         opacity: 0 !important; /* Make icon transparent */
-        -moz-margin-end: -1.1em !important; /* Hide icon by offsetting it */
+        -moz-margin-end: -1.4em !important; /* Hide icon by offsetting it */
 }
 
-/* Show the reload button on address bar hover */
-#urlbar:hover .webextension-page-action[id="_e1ed7a80-7c11-4f7e-968b-79b551a0067f_-page-action"] {
+/* Show the reload button on navbar hover */
+#urlbar:hover .webextension-page-action[id="_e1ed7a80-7c11-4f7e-968b-79b551a0067f_-page-action"], 
+#urlbar:hover .webextension-page-action[id="_7afe2ae8-0244-48d6-8007-6aadad9a6090_-page-action"],
+#urlbar:hover .webextension-page-action[id="reload-in-urlbar_exe-boss-page-action"] {
         transition: 300ms !important; /* Animate icon showing */
         opacity: 1 !important; /* Make the icon opaque */
         -moz-margin-end: initial !important; /* Use initial margins to show the icon */

--- a/extensions/autohide-reload-in-address-bar.css
+++ b/extensions/autohide-reload-in-address-bar.css
@@ -7,10 +7,10 @@
  * Contributor(s): Madis0
  */
 
-/* Hide the extension's reload button by default */
-#urlbar .webextension-page-action[id="_e1ed7a80-7c11-4f7e-968b-79b551a0067f_-page-action"], 
-#urlbar .webextension-page-action[id="_7afe2ae8-0244-48d6-8007-6aadad9a6090_-page-action"], 
-#urlbar .webextension-page-action[id="reload-in-urlbar_exe-boss-page-action"] {
+/* Hide the extension's reload button by default, except for stop buttons */
+#urlbar .webextension-page-action[id="_e1ed7a80-7c11-4f7e-968b-79b551a0067f_-page-action"]:not([aria-label="Stop"]), 
+#urlbar .webextension-page-action[id="_7afe2ae8-0244-48d6-8007-6aadad9a6090_-page-action"],
+#urlbar .webextension-page-action[id="reload-in-urlbar_exe-boss-page-action"]:not([aria-label="Stop"]) {
         transition: 300ms !important; /* Animate icon hiding */
         opacity: 0 !important; /* Make icon transparent */
         -moz-margin-end: -1.4em !important; /* Hide icon by offsetting it */

--- a/extensions/autohide-reload-in-address-bar.css
+++ b/extensions/autohide-reload-in-address-bar.css
@@ -13,7 +13,7 @@
 #urlbar .webextension-page-action[id="reload-in-urlbar_exe-boss-page-action"]:not([aria-label="Stop"]) {
         transition: 300ms !important; /* Animate icon hiding */
         opacity: 0 !important; /* Make icon transparent */
-        -moz-margin-end: -1.4em !important; /* Hide icon by offsetting it */
+        -moz-margin-end: -1.5em !important; /* Hide icon by offsetting it */
 }
 
 /* Show the reload button on navbar hover */


### PR DESCRIPTION
Automatically hides [the icon of this extension](https://addons.mozilla.org/en-US/firefox/addon/reload-in-address-bar/), showing up only on address bar hover.