### PR TITLE
Hide address bar dropmarker

### DIFF
--- a/navbar/hide-addressbar-dropmarker.css
+++ b/navbar/hide-addressbar-dropmarker.css
@@ -1,0 +1,9 @@
+/*
+ * Hides the address bar history dropmarker permanently.
+ *
+ * Contributor(s): Madis0
+ */
+
+.urlbar-history-dropmarker{
+  display: none !important;
+}


### PR DESCRIPTION
Hides the address bar dropmarker permanently, so it won't appear on hover.