### PR TITLE
Hide PageAction separator

### DIFF
--- a/navbar/hide-pageaction-separator.css
+++ b/navbar/hide-pageaction-separator.css
@@ -1,0 +1,9 @@
+/*
+ * Hides the separator between address bar PageAction extensions and internal icons (Containers, Reader, etc.)
+ *
+ * Contributor(s): Madis0
+ */
+
+#pageActionSeparator{
+  display: none;
+}


### PR DESCRIPTION
Hides the separator between address bar PageAction extensions and internal icons (Containers, Reader, etc.)