### PR TITLE
Underline and dim pending tabs

### DIFF
--- a/tabs/underline-pending-tabs.css
+++ b/tabs/underline-pending-tabs.css
@@ -1,0 +1,10 @@
+/*
+ * Underlines and dims unloaded tabs
+ *
+ * Contributor(s): josemam
+ */
+
+.tabbrowser-tab[pending] {
+  text-decoration: underline;
+  opacity: .5;
+}


### PR DESCRIPTION
This tweak underlines and dims unloaded tabs, i.e. the tabs from a restored Firefox session that have not yet been selected and the tabs that have been unloaded by an extension, so they can be told apart from the ready ones.