### PR TITLE
Stop as throbber

### DIFF
--- a/navbar/reload-stop-throbber.css
+++ b/navbar/reload-stop-throbber.css
@@ -1,0 +1,13 @@
+/*
+ * Shows the tab throbber instead of the stop button while the page loads. Hover will change it back to stop button.
+ *
+ * Contributor(s): Madis0
+ */
+
+#stop-reload-button:not([animate]) > #stop-button {
+    list-style-image: url("chrome://browser/skin/tabbrowser/tab-loading.png") !important; /* Show throbber after the reload-to-stop animation, until stop-to-reload animation */
+}
+
+#stop-reload-button > #stop-button:hover {
+  list-style-image: url("chrome://browser/skin/stop.svg") !important; /* Show stop button on hover */
+}


### PR DESCRIPTION
Makes the stop button use the "throbber" animation currently used only on tabs.

Uses the fallback APNG which is _not_ synced with tabs' throbbers, so don't use it if you have OCD 😁 