### PR TITLE
Important updates on tabs/remove-padding-when-not-maximized-macOS-Windows.css

### DIFF
--- a/tabs/remove-padding-when-not-maximized-macOS-Windows.css
+++ b/tabs/remove-padding-when-not-maximized-macOS-Windows.css
@@ -6,6 +6,34 @@
  * Contributor(s): Gacel Perfinian
  */
 
-.titlebar-placeholder[type="pre-tabs"], .titlebar-placeholder[type="post-tabs"] {
+/*
+ * Instead of hiding the padding, you can adjust the padding.
+ * As of Firefox Quantum, it is set at around 40 pixels
+ * (the exact amount depends on the specific theming done and
+ * the operating system).
+ * To override, instead of placing display:none
+ * use width: Xpx !important;
+ * or width: Xem !important;
+ */
+
+.titlebar-placeholder[type="pre-tabs"] {
   display:none !important;
 }
+
+/* Unless you have a specific problem
+ * (for example, having a very small screen)
+ * this should be left as-is. Only uncomment
+ * it when the benefit is better than the side effects.
+ * Reported side effects including undraggable windows
+ * and lost new tab button.
+ * note that if your display is RTL, the above code should
+ * still work.
+ */
+
+/*
+
+.titlebar-placeholder[type="post-tabs"] {
+  display:none !important;
+}
+
+*/

--- a/tabs/remove-padding-when-not-maximized-macOS-Windows.css
+++ b/tabs/remove-padding-when-not-maximized-macOS-Windows.css
@@ -26,7 +26,7 @@
  * it when the benefit is better than the side effects.
  * Reported side effects including undraggable windows
  * and lost new tab button.
- * note that if your display is RTL, the above code should
+ * Note that if your display is RTL, the above code should
  * still work.
  */
 


### PR DESCRIPTION
This is a patch with important bug fixes and improved code.

### Important bugfix - `[post-tabs]` should be left as is

The `[post-tabs]` portion, when enabled, triggers some bugs as reported by some users and in my personal experience. This includes undraggable windows (which is unmovable even when using the keyboard shortcuts) and hiding new tab button (probably by design).

### Improvements

Added comments to better facilitate its use. Read the modified file to learn what are the new comments.