### PR TITLE
Update selectors based on reddit article.

### DIFF
--- a/toolbars/show-bookmarks-only-on-newtab.css
+++ b/toolbars/show-bookmarks-only-on-newtab.css
@@ -5,6 +5,7 @@
  * Video: https://vimeo.com/240436456
  *
  * Contributor(s): https://www.reddit.com/user/AJtfM7zT4tJdaZsm and Andrei Cristian Petcu
+ *                 https://www.reddit.com/r/FirefoxCSS/comments/7evwow/show_bookmarks_toolbar_only_on_new_tab/
  */
 
 #main-window #PersonalToolbar {
@@ -13,6 +14,8 @@
 
 #main-window[title^="about:newtab"] #PersonalToolbar,
 #main-window[title^="New Tab"] #PersonalToolbar,
-#main-window[title^="Nightly"] #PersonalToolbar {
+#main-window[title^="Nightly"] #PersonalToolbar,
+#main-window[title^="Mozilla Firefox"] #PersonalToolbar,
+#main-window[title^="Firefox"] #PersonalToolbar {
   visibility: visible !important;
 }


### PR DESCRIPTION
I recently started using Firefox Nightly (`59.0`) and wanted to have Chromium-like behavior with regard to the bookmarks bar only showing on the new tab page.

https://www.reddit.com/r/FirefoxCSS/comments/7evwow/show_bookmarks_toolbar_only_on_new_tab/

![works-on-my-machine-badge-small](https://user-images.githubusercontent.com/514926/33390622-51a245b8-d4eb-11e7-990b-06a87f610780.png)
