### PR TITLE
Create autohide-tracking-protection

### DIFF
--- a/navbar/autohide-tracking-protection
+++ b/navbar/autohide-tracking-protection
@@ -1,0 +1,13 @@
+/*
+ * Description: Hides the Tracking Protection icon.
+ *
+ * Contributor: Joachim Vandersmissen
+ */
+
+#tracking-protection-icon {
+  visibility: collapse !important;
+}
+
+#identity-box:hover > #tracking-protection-icon {
+  visibility: visible !important;
+}


### PR DESCRIPTION
This tweak hides the Tracking Protection icon by default. Hovering over the identity box will reveal the icon.