### PR TITLE
[more-compact-tabs.css] compact buttons in tab bar

### DIFF
--- a/tabs/more-compact-tabs.css
+++ b/tabs/more-compact-tabs.css
@@ -18,3 +18,12 @@
   margin: var(--newtab-margin) !important;
 }
 
+#TabsToolbar > .toolbarbutton-1 {
+  margin-bottom: 0 !important;
+  max-height: var(--tab-min-height) !important;
+}
+
+#TabsToolbar > .toolbarbutton-1 > .toolbarbutton-badge-stack, .toolbarbutton-icon {
+  padding-top: 1px !important;
+  padding-bottom: 1px !important;
+}


### PR DESCRIPTION
If some buttons are located in the tab bar, they extend it to 27px. Buttons can come from extension, or Firefox itself (with the "all-tabs" dropdown).
This patch should avoid the vertical expansion.