### PR TITLE
(move-identity-lock-right.css) Fix omnibar suggestions panel

### DIFF
--- a/navbar/move-identity-lock-right.css
+++ b/navbar/move-identity-lock-right.css
@@ -6,7 +6,7 @@
  */
 
 #PopupAutoCompleteRichResult .autocomplete-richlistitem {
-  padding-inline-start: var(--item-padding-end);
+  padding-inline-start: var(--item-padding-end) !important;
 }
 
 #urlbar > #identity-box

--- a/navbar/move-identity-lock-right.css
+++ b/navbar/move-identity-lock-right.css
@@ -2,8 +2,12 @@
  * Move the identity icon and SSL lock to the end of the address bar, 
  * move/adjust the 3-dot page action button to make it look better
  *
- * Contributor(s): Madis0
+ * Contributor(s): Madis0, Mart3323
  */
+
+#PopupAutoCompleteRichResult .autocomplete-richlistitem {
+  padding-inline-start: var(--item-padding-end);
+}
 
 #urlbar > #identity-box
 {


### PR DESCRIPTION
--item-padding-start for #PopupAutoCompleteRichResult seems to be getting an unusually large value when the thing is aligned right.
meanwhile, --item-padding-end is exactly the right width that we can use it for both sides now.

I'm not sure if this is correct, but it seems to work okay for different window sizes.