### PR TITLE
Shrink toolbar buttons in tab bar

### DIFF
--- a/tabs/more-compact-tabs.css
+++ b/tabs/more-compact-tabs.css
@@ -18,3 +18,14 @@
   margin: var(--newtab-margin) !important;
 }
 
+[uidensity="compact"]:root #TabsToolbar > .toolbarbutton-1 {
+  margin-bottom: 0 !important;
+  max-height: var(--tab-min-height) !important;
+  
+}
+
+[uidensity="compact"]:root #TabsToolbar > .toolbarbutton-1 > .toolbarbutton-badge-stack,
+[uidensity="compact"]:root #TabsToolbar > .toolbarbutton-1 .toolbarbutton-icon{
+  padding-top: 1px !important;
+  padding-bottom: 1px !important;
+}


### PR DESCRIPTION
If some buttons are present in tab bar (e.g. extensions icons), then they enlarge the bar height. This should shrink them to fit.