### PR TITLE
Fix to include --tab-min-height for Firefox 60

### DIFF
--- a/toolbars/auto-hide.css
+++ b/toolbars/auto-hide.css
@@ -6,14 +6,17 @@
 
 :root[uidensity=compact] #navigator-toolbox {
   --nav-bar-height: 33px;
+  --tab-min-height: 29px;
 }
 
 :root:not([uidensity]) #navigator-toolbox {
   --nav-bar-height: 39px;
+  --tab-min-height: 33px;
 }
 
 :root[uidensity=touch] #navigator-toolbox {
   --nav-bar-height: 41px;
+  --tab-min-height: 41px;
 }
 
 #navigator-toolbox {


### PR DESCRIPTION
Which was removed from root by https://bugzilla.mozilla.org/show_bug.cgi?id=1435993