### PR TITLE
auto-hide-sidebar-treestyletabs.css

### DIFF
--- a/sidebar/auto-hide-sidebar-tst.css
+++ b/sidebar/auto-hide-sidebar-tst.css
@@ -8,37 +8,37 @@
  */
 
 #sidebar {
-    max-width: none!important;
-    min-width: 0!important
+  max-width: none!important;
+  min-width: 0!important
 }
 
 #sidebar-box+#sidebar-splitter {
-    display: none!important
+  display: none!important
 }
 
 #sidebar-box[sidebarcommand=treestyletab_piro_sakura_ne_jp-sidebar-action] #sidebar-header {
-    visibility: collapse
+  visibility: collapse
 }
 
 :root {
-    --thin-tab-width: 35px;
-    --wide-tab-width: 280px
+  --thin-tab-width: 35px;
+  --wide-tab-width: 280px
 }
 
 #sidebar-box {
-    overflow: hidden!important;
-    position: relative!important;
-    transition: all 100ms!important;
-    min-width: var(--thin-tab-width)!important;
-    max-width: var(--thin-tab-width)!important
+  overflow: hidden!important;
+  position: relative!important;
+  transition: all 100ms!important;
+  min-width: var(--thin-tab-width)!important;
+  max-width: var(--thin-tab-width)!important
 }
 
 #sidebar-box #sidebar,#sidebar-box:hover {
-    transition: all 100ms!important;
-    min-width: var(--wide-tab-width)!important;
-    max-width: var(--wide-tab-width)!important
+  transition: all 100ms!important;
+  min-width: var(--wide-tab-width)!important;
+  max-width: var(--wide-tab-width)!important
 }
 
 #sidebar-box:hover {
-    margin-right: calc((var(--wide-tab-width) - var(--thin-tab-width))*-1)!important
+  margin-right: calc((var(--wide-tab-width) - var(--thin-tab-width))*-1)!important
 }

--- a/sidebar/auto-hide-sidebar-tst.css
+++ b/sidebar/auto-hide-sidebar-tst.css
@@ -1,0 +1,44 @@
+/*
+ * Description: A firefox userChrome.css modification to autohide sidebar when not in focus. It is based on the work of "TanzNukeTerror" and intended to be used with TreeStyleTabs.
+ *
+ * Screenshot: Original Theme - https://i.imgur.com/NKvSAYZ.jpg
+ *
+ * Contributor(s): img2tab, Chris Morgan, TanzNukeTerror, radamar
+ * 
+ */
+
+#sidebar {
+    max-width: none!important;
+    min-width: 0!important
+}
+
+#sidebar-box+#sidebar-splitter {
+    display: none!important
+}
+
+#sidebar-box[sidebarcommand=treestyletab_piro_sakura_ne_jp-sidebar-action] #sidebar-header {
+    visibility: collapse
+}
+
+:root {
+    --thin-tab-width: 35px;
+    --wide-tab-width: 280px
+}
+
+#sidebar-box {
+    overflow: hidden!important;
+    position: relative!important;
+    transition: all 100ms!important;
+    min-width: var(--thin-tab-width)!important;
+    max-width: var(--thin-tab-width)!important
+}
+
+#sidebar-box #sidebar,#sidebar-box:hover {
+    transition: all 100ms!important;
+    min-width: var(--wide-tab-width)!important;
+    max-width: var(--wide-tab-width)!important
+}
+
+#sidebar-box:hover {
+    margin-right: calc((var(--wide-tab-width) - var(--thin-tab-width))*-1)!important
+}


### PR DESCRIPTION
The original auto-hide-sidebar.css from img2tab didn't work for me somehow. But [this one][1] did from [TanzNukeTerror][2], I found this one to be a really useful mod that get's a lot right in a single package. 
What is working:
1. The sidebar is working smooth without any glitches for weeks now.
2. The tabs have proper indents to show the parent-child hierarchy. Helps to map the tabs in your brain.

A slight modification allowed it to autohide other sidebars too, and it looks fantastic combined with [ShadowFox][3]

[1]: https://www.reddit.com/r/FirefoxCSS/comments/7emhsq/my_compact_treestyletab_css_and_sidebar_hover/
[2]: https://github.com/TanzNukeTerror/Custom-Firefox
[3]: https://github.com/overdodactyl/ShadowFox