### PR TITLE
Update more-compact-tabs for Firefox >= 60

### DIFF
--- a/tabs/more-compact-tabs.css
+++ b/tabs/more-compact-tabs.css
@@ -10,6 +10,10 @@
   --newtab-margin: -3px 0 -3px -3px !important;
 }
 
+:root[uidensity="compact"] #tabbrowser-tabs {
+  --tab-min-height: var(--tab-min-height) !important;
+}
+
 .tabbrowser-tab {
   max-height: var(--tab-min-height) !important;
 }


### PR DESCRIPTION
The enclosing elements now have a tab-min-height.