### PR TITLE
Create elementaryos-like-btn-position.css

### DIFF
--- a/titlebar/elementaryos-like-btn-position.css
+++ b/titlebar/elementaryos-like-btn-position.css
@@ -1,0 +1,41 @@
+/*
+ * Elementary OS like window buttons.
+ * Close (C) on the left, maximize (M) on the right
+ * no minimize (m)
+ *
+ * (ideal with title bar disabled)
+ *
+ * Contributor(s): Bleznudd
+ * https://github.com/Bleznudd/
+ *
+ */
+
+#titlebar-buttonbox {
+	display: flex !important;
+	flex-direction: row-reverse !important; /*reverse buttons order (C:M:m)*/
+}
+.titlebar-placeholder[type="pre-tabs"] {
+	display: -moz-box !important;
+	width: 38px !important; /*reserving some pixels of space for the C btn*/
+	border: 0 !important;
+}
+#titlebar-close{
+	display: -moz-box !important;
+	margin-right: calc(100vw - 34px - 34px) !important;
+	/*setting a loooong C btn right-margin (long nearly as the window width)*/
+}
+#titlebar-max{
+	display: -moz-box !important;
+}
+#titlemar-min{
+	display: none !important;		/*hiding m btn*/
+}
+#titlebar-spacer {
+	max-width: 0px !important;		/*setting 0 pixels long title spacer*/
+	display: -moz-box !important;	/*or display: none !important*/
+}
+#tabbrowser-tabs{
+	max-width: calc(100vw - 70px - 80px) !important;
+	min-width: calc(100vw - 70px - 80px) !important;
+	z-index: 2 !important; /*putting tabs-bar over buttonbox*/
+}


### PR DESCRIPTION
[Elementary OS](https://elementary.io/it/) like window buttons. 
Close (C) on the left, maximize (M) on the right, no minimize (m).
Ideal with title bar disabled for saving some screen space without loosing the system UI style.

**Screenshot:**
![image](https://user-images.githubusercontent.com/33193871/40492357-9a92c7c4-5f70-11e8-8cc0-5e9429be2fa0.png)

Tested on:
- Firefox 60.0.1
- Manjaro 17.1.10 Hakoila


**P.S.:** Sorry for adding a new folder, but none of the existing fit