### PR TITLE
Hide one-off-search header

### DIFF
--- a/navbar/hide-oneoffsearch-header.css
+++ b/navbar/hide-oneoffsearch-header.css
@@ -1,0 +1,10 @@
+/*
+ * Hides the header of the one-off-search buttons (the one that says "Search ... with:") on 
+ * the address bar and search bar autocomplete item list. Also hides "hide search settings" on search bar.
+ *
+ * Contributor(s): Madis0
+ */
+ 
+.search-panel-header {
+  display: none !important;
+}


### PR DESCRIPTION
Would've used a more specific targeting, but it didn't want to work with one, so I hope it doesn't break anything.