### PR TITLE
Hide bookmarks bar when folded

### DIFF
--- a/toolbars/sliding-bookmarks-bar.css
+++ b/toolbars/sliding-bookmarks-bar.css
@@ -18,14 +18,17 @@
   width: 100%;
   transform: translateY(-100%);
   transition: transform 0.2s !important;
+  opacity: 0;
 }
 
 #navigator-toolbox:hover >
 #nav-bar ~ #PersonalToolbar:not([customizing]) {
   transform: translateY(0);
+  opacity: 1;
 }
 
 #toolbar-menubar:not([inactive="true"]) ~
 #nav-bar ~ #PersonalToolbar:not([customizing]) {
   transform: translateY(0);
+  opacity: 1;
 }


### PR DESCRIPTION
Add opacity to hide bookmarks bar when folded. This resolv a bug that the folded bookmark bar is in front of extentions and hamburger button.