### PR TITLE
Configure background color of new tabs while loading (white flash)

### DIFF
--- a/tabs/change-newtab-background-color.css
+++ b/tabs/change-newtab-background-color.css
@@ -1,0 +1,23 @@
+/*
+ * Description: Changes the background color of newly opened tabs
+ *              to prevent white flashes 
+ *
+ * Contributor: Nicola Zanardi
+ */
+
+@-moz-document url(chrome://browser/content/browser.xul)
+{
+
+  #main-window,
+  browser[type="content-primary"],
+  browser[type="content"],
+  tabbrowser#content,
+  #content,
+  browser[type="content"] > html
+  {
+     /* The background is set to black now, but any color can be used */
+     background: #000000 !important;
+  }
+
+}
+


### PR DESCRIPTION
This css is to remove/change the default background color of an empty new tab, the current selection is black.
It can also be used to remove the annoying white flash that happens when a new tab is opened and a replacement for the new tab is used, like Tabliss