### PR TITLE
Move transition property from :hover to normal.

### DIFF
--- a/toolbars/auto-hide.css
+++ b/toolbars/auto-hide.css
@@ -58,13 +58,13 @@
 :root:not([customizing]) #nav-bar:focus-within {
   max-height: var(--nav-bar-height);
   opacity: 1;
-  transition: opacity 0.15s ease-in, max-height 0.15s linear;
 }
 
 :root:not([customizing]) #navigator-toolbox {
   max-height: calc(var(--tabbar-height) + var(--trigger-area-height));
   min-height: var(--tabbar-height);
   margin-bottom: calc(-1 * var(--trigger-area-height));
+  transition: opacity 0.15s ease-in, max-height 0.15s linear;
 }
 
 :root:not([customizing]) #navigator-toolbox:hover,
@@ -78,13 +78,13 @@
   max-height: 0 !important;
   min-height: 0.1px !important;
   opacity: 0;
-  transition: opacity 0.15s ease-in !important;
 }
 
 :root:not([customizing]) :hover > #PersonalToolbar,
 :root:not([customizing]) #navigator-toolbox:focus-within #PersonalToolbar {
   max-height: 4em !important;
   opacity: 1;
+  transition: opacity 0.15s ease-in !important;
 }
 
 /* Lightweight Theme Support */


### PR DESCRIPTION
Right now when you move the mouse out of range it just kind of lurches out of existence, and that's a bit weird so I moved that transition property to the "normal" state instead of just :hover.