### PR TITLE
Support the extra drag space option in auto-hide.css

### DIFF
--- a/toolbars/auto-hide.css
+++ b/toolbars/auto-hide.css
@@ -9,14 +9,29 @@
   --tab-min-height: 29px;
 }
 
+:root[uidensity=compact][extradragspace]:not([sizemode="normal"]) #navigator-toolbox {
+  --nav-bar-height: 33px;
+  --tab-min-height: 21px;
+}
+
 :root:not([uidensity]) #navigator-toolbox {
   --nav-bar-height: 39px;
   --tab-min-height: 33px;
 }
 
+:root:not([uidensity])[extradragspace]:not([sizemode="normal"]) #navigator-toolbox {
+  --nav-bar-height: 39px;
+  --tab-min-height: 25px;
+}
+
 :root[uidensity=touch] #navigator-toolbox {
   --nav-bar-height: 41px;
   --tab-min-height: 41px;
+}
+
+:root[uidensity=touch][extradragspace]:not([sizemode="normal"]) #navigator-toolbox {
+  --nav-bar-height: 41px;
+  --tab-min-height: 33px;
 }
 
 #navigator-toolbox {


### PR DESCRIPTION
Adds an extra set of rules that apply to non-maximized windows with extra drag space enabled. The extra drag space steals about 8 pixels of height from the tabs, so when that option is enabled and when the window is not maximized, we need to adjust the tab height.