### PR TITLE
Hide unused padding

### DIFF
--- a/toolbars/roomy-bookmarks-toolbar.css
+++ b/toolbars/roomy-bookmarks-toolbar.css
@@ -26,6 +26,9 @@ toolbarbutton.bookmark-item[type="menu"] .toolbarbutton-text {
 }
 /* Show the folder icon only if the label is blank */
 toolbarbutton.bookmark-item[type="menu"] .toolbarbutton-icon[label]:not([label=""]) {
-	width: 0px;
+	width: 0px !important;
 }
-
+/* Hide the little bit of padding between the icon and label */
+#PlacesToolbarItems > .bookmark-item > .toolbarbutton-icon[label]:not([label=""]) {
+  margin-inline-end: 0px !important;
+}


### PR DESCRIPTION
With this snippet the icon and label are never shown at the same time, but the padding between them still exists between them. Also tack on an !important to the bit that hides the icons. I could not get it to work without it which is just bizarre because it really should. The native bit that's overriding it is less specific and doesn't use !important either so I have no idea what's going on there.