### PR TITLE
Add Chinese locale support for show-bookmarks-only-on-newtab.css

### DIFF
--- a/toolbars/show-bookmarks-only-on-newtab.css
+++ b/toolbars/show-bookmarks-only-on-newtab.css
@@ -16,6 +16,7 @@
 #main-window[title^="New Tab"] #PersonalToolbar,
 #main-window[title^="Nightly"] #PersonalToolbar,
 #main-window[title^="Mozilla Firefox"] #PersonalToolbar,
-#main-window[title^="Firefox"] #PersonalToolbar {
+#main-window[title^="Firefox"] #PersonalToolbar,
+#main-window[title^="新标签页"] #PersonalToolbar {
   visibility: visible !important;
 }


### PR DESCRIPTION
Fixed an issue where the bookmarks bar disappears when switching back to the new-tab page from other pages if the browser language is Chinese.