### PR TITLE
Add hide-bookmark-confirmation-hint.css

### DIFF
--- a/toolbars/hide-bookmark-confirmation-hint.css
+++ b/toolbars/hide-bookmark-confirmation-hint.css
@@ -1,0 +1,11 @@
+/*
+ * Description: Hides the confirmation hint after bookmarking a web page
+ *
+ * Screenshot: https://i.fiery.me/IgZe.png
+ *
+ * Contributor(s): Strappazzon
+ */
+
+#confirmation-hint {
+  display: none !important
+}


### PR DESCRIPTION
This tweak will hide the confirmation hint that appears shortly after bookmarking a web page.
Tested on Firefox 66.0.5

**Screenshot for reference:**

![IgZe 1](https://user-images.githubusercontent.com/19752093/57479613-138e4180-729e-11e9-98be-21a5d49a689d.png)
