### PR TITLE
Update remove-padding-when-not-maximized-macOS-Windows.css

### DIFF
--- a/tabs/remove-padding-when-not-maximized-macOS-Windows.css
+++ b/tabs/remove-padding-when-not-maximized-macOS-Windows.css
@@ -16,7 +16,7 @@
  * or width: Xem !important;
  */
 
-.titlebar-placeholder[type="pre-tabs"] {
+.titlebar-spacer[type="pre-tabs"] {
   display:none !important;
 }
 


### PR DESCRIPTION
`titlebar-spacer` is used instead of `titlebar-placeholder` in Firefox 67.0.1 on macOS.
Should be the same for all Firefox versions. I didn't confirm it though.