### PR TITLE
Hide tabs on Firefox 71 (MacOS)

### DIFF
--- a/tabs/hide-tabs-macos.css
+++ b/tabs/hide-tabs-macos.css
@@ -8,16 +8,17 @@
  * Contributor(s): Isaac-Newt, Ivan0xFF, millerdev
  */
 
-#TabsToolbar {
+#titlebar {
   visibility: collapse;
 }
 
 /* Position window controls */
-.titlebar-buttonbox-container {
+#TabsToolbar .titlebar-buttonbox-container {
+  display: block;
   position: absolute;
   visibility: visible;
-  margin-left: 5px;
-  margin-top: 5px;
+  margin-left: 2px;
+  margin-top: 2px;
 }
 
 /*


### PR DESCRIPTION
Bring back the close/min/max buttons, which were not visible after updating Firefox.

Ref. https://www.reddit.com/r/FirefoxCSS/comments/e7br59/hide_titlebar_and_tabs_in_firefox_71/