### PR TITLE
working version of auto-hide.css for Firefox 72

### DIFF
--- a/toolbars/auto-hide.css
+++ b/toolbars/auto-hide.css
@@ -1,126 +1,25 @@
 /*
- * Auto-hide the URL-bar and bookmarks bar, show on hover or focus
- *
- * Contributor(s): Alex Vallat
+ * Auto-hide the URL-bar show on hover or focus
+ * as seen in https://www.reddit.com/r/FirefoxCSS/comments/boetx7/annoying_page_jump_with_address_bar_autohide/engne27/
+ * slightly modified for more responsiveness
+ * 
+ * note that this version DOES NOT hide the bookmarks toolbar
  */
-
-:root[uidensity=compact] #navigator-toolbox {
-  --nav-bar-height: 33px;
-  --tab-min-height: 29px;
+#nav-bar:not([customizing="true"]):not([inFullscreen]) {
+	min-height: 1px !important;
+	max-height: 0px !important;
+	margin-top: 1px !important;
+	margin-bottom: -1px !important;
+	transition: all 50ms linear 0s !important;
+	z-index: -5 !important;
 }
 
-:root[uidensity=compact][extradragspace]:not([sizemode="normal"]) #navigator-toolbox {
-  --nav-bar-height: 33px;
-  --tab-min-height: 21px;
-}
-
-:root:not([uidensity]) #navigator-toolbox {
-  --nav-bar-height: 39px;
-  --tab-min-height: 33px;
-}
-
-:root:not([uidensity])[extradragspace]:not([sizemode="normal"]) #navigator-toolbox {
-  --nav-bar-height: 39px;
-  --tab-min-height: 25px;
-}
-
-:root[uidensity=touch] #navigator-toolbox {
-  --nav-bar-height: 41px;
-  --tab-min-height: 41px;
-}
-
-:root[uidensity=touch][extradragspace]:not([sizemode="normal"]) #navigator-toolbox {
-  --nav-bar-height: 41px;
-  --tab-min-height: 33px;
-}
-
-#navigator-toolbox {
-  --tabbar-height: calc(var(--tab-min-height) + var(--space-above-tabbar));
-  --trigger-area-height: 5px;
-}
-
-:root[chromehidden~="toolbar"] #navigator-toolbox {
-  --tabbar-height: 0.1px;
-}
-
-#toolbar-menubar {
-  margin-top: 0px !important; /* This is usually 0, but under Win7 can be given an extra 1px when not maximized */
-}
-
-/* Undo add of 4px extra margin on top of the tabs toolbar on Windows 7. */
-/* Note: @media -moz-os-version does not work in userChrome.css (https://bugzilla.mozilla.org/show_bug.cgi?id=1418963) */
-:root[sizemode="normal"][chromehidden~="menubar"] #TabsToolbar,
-:root[sizemode="normal"] #toolbar-menubar[autohide="true"][inactive] + #TabsToolbar {
-  padding-top: var(--space-above-tabbar) !important;
-}
-
-#nav-bar, #PersonalToolbar {
-	/* Otherwise spacers will not count as hover-able areas */
-    -moz-window-dragging: default;
-}
-
-:root:not([customizing]) #nav-bar
-{
-  overflow-y: hidden;
-  max-height:0;
-  min-height:0 !important;
-  padding-top:0 !important;
-  padding-bottom:0 !important;
-  opacity: 0;
-}
-
-:root:not([customizing]) :hover > #nav-bar,
-:root:not([customizing]) #nav-bar:focus-within {
-  max-height: var(--nav-bar-height);
-  opacity: 1;
-}
-
-:root:not([customizing]) #navigator-toolbox {
-  max-height: calc(var(--tabbar-height) + var(--trigger-area-height));
-  min-height: var(--tabbar-height);
-  margin-bottom: calc(-1 * var(--trigger-area-height));
-  transition: opacity 0.15s ease-in, max-height 0.15s linear;
-}
-
-:root:not([customizing]) #navigator-toolbox:hover,
-:root:not([customizing]) #navigator-toolbox:focus-within {
-  max-height: calc(var(--tabbar-height) + var(--nav-bar-height));
-  margin-bottom: calc(0px - var(--nav-bar-height));
-}
-
-/* If the bookmarks bar is turned on, auto-hide that too */
-:root:not([customizing]) #PersonalToolbar {
-  max-height: 0 !important;
-  min-height: 0.1px !important;
-  opacity: 0;
-}
-
-:root:not([customizing]) :hover > #PersonalToolbar,
-:root:not([customizing]) #navigator-toolbox:focus-within #PersonalToolbar {
-  max-height: 4em !important;
-  opacity: 1;
-  transition: opacity 0.15s ease-in !important;
-}
-
-/* Lightweight Theme Support */
-:root:-moz-lwtheme #nav-bar, 
-:root:-moz-lwtheme #PersonalToolbar {
-  background-color: var(--lwt-accent-color) !important;
-  background-image: var(--lwt-header-image), var(--lwt-additional-images) !important;
-  background-position: var(--lwt-background-alignment) !important;
-  background-repeat: var(--lwt-background-tiling) !important;
-}
-
-#main-window[sizemode="normal"]:-moz-lwtheme #nav-bar {
-    background-position-y: calc(-2px - var(--tabbar-height)) !important;
-}
-#main-window[sizemode="normal"]:-moz-lwtheme #PersonalToolbar {
-    background-position-y: calc(-2px - var(--tabbar-height) - var(--nav-bar-height)) !important;
-}
-
-#main-window[sizemode="maximized"]:-moz-lwtheme #nav-bar {
-    background-position-y: calc(-8px - var(--tabbar-height)) !important;
-}
-#main-window[sizemode="maximized"]:-moz-lwtheme #PersonalToolbar {
-    background-position-y: calc(-8px - var(--tabbar-height) - var(--nav-bar-height)) !important;
+#navigator-toolbox:hover:not([inFullscreen]) :-moz-any(#nav-bar),
+#navigator-toolbox:focus-within :-moz-any(#nav-bar) {
+	min-height: 32px !important;
+	max-height: 32px !important;
+	margin-top: 1px !important;
+	margin-bottom: -32px !important;
+	transition: all 50ms linear 0s !important;
+	z-index: 5 !important;
 }

--- a/toolbars/auto-hide.css
+++ b/toolbars/auto-hide.css
@@ -1,9 +1,11 @@
 /*
  * Auto-hide the URL-bar show on hover or focus
  * as seen in https://www.reddit.com/r/FirefoxCSS/comments/boetx7/annoying_page_jump_with_address_bar_autohide/engne27/
+ * by https://www.reddit.com/user/SkyrimForTheDragons/
+ *
  * slightly modified for more responsiveness
  * 
- * note that this version DOES NOT hide the bookmarks toolbar
+ * Note that this version DOES NOT hide the bookmarks toolbar!
  */
 #nav-bar:not([customizing="true"]):not([inFullscreen]) {
 	min-height: 1px !important;


### PR DESCRIPTION
Fixes https://github.com/Timvde/UserChrome-Tweaks/issues/157, might fix https://github.com/Timvde/UserChrome-Tweaks/issues/152 and https://github.com/Timvde/UserChrome-Tweaks/issues/150 as well. This version DOES NOT hide the bookmarks toolbar.