### PR TITLE
Add compact-navbar-breakout.css

### DIFF
--- a/navbar/compact-navbar-breakout.css
+++ b/navbar/compact-navbar-breakout.css
@@ -1,0 +1,43 @@
+/*
+ * Reduces the padding/margins on the new (since Firefox 75) "breakout" navbar dropdown,
+ * so it looks less like a mobile layout
+ *
+ * Contributor(s): udf
+ */
+
+/* Remove padding on urlbar results */
+.urlbarView-row {
+  padding-top: 0px !important;
+  padding-bottom: 0px !important;
+}
+
+/* Remove padding on urlbar (icons on the right break without this) */
+#urlbar-input-container {
+  padding-top: 0px !important;
+  padding-bottom: 0px !important;
+}
+
+/* Reduce "breakout" navbar height */
+#urlbar[breakout][breakout-extend] > #urlbar-input-container {
+  height: calc(var(--urlbar-toolbar-height) - 4px) !important;
+}
+
+/* Fix breakout positioning being too high after we decreased the height */
+#urlbar[breakout][breakout-extend] {
+  top: 2px !important;
+}
+
+/* Remove padding on search one offs div */
+.search-one-offs {
+  padding-block: 0px !important;
+}
+
+/* Fix padding left of the search one-off icons */
+.search-panel-one-offs {
+  padding-left: 7px !important;
+}
+
+/* Remove margins around the search one-off icons */
+.searchbar-engine-one-off-item {
+  margin: 0px !important;
+}

--- a/navbar/compact-navbar-breakout.css
+++ b/navbar/compact-navbar-breakout.css
@@ -2,6 +2,8 @@
  * Reduces the padding/margins on the new (since Firefox 75) "breakout" navbar dropdown,
  * so it looks less like a mobile layout
  *
+ * Screenshot: https://github.com/Timvde/UserChrome-Tweaks/pull/170
+ *
  * Contributor(s): udf
  */
 


### PR DESCRIPTION
Compacts the new breakout navbar in Firefox 75 so it looks less like a mobile layout and more like a desktop layout.

Turns this:
![image](https://user-images.githubusercontent.com/13610073/78923490-91536200-7a98-11ea-89f9-67516e4937db.png)
into this:
![image](https://user-images.githubusercontent.com/13610073/78923497-957f7f80-7a98-11ea-8325-65c7ea6973c2.png)
