### PR TITLE
Update hide-tabs-macos for Big Sur

### DIFF
--- a/tabs/hide-tabs-macos.css
+++ b/tabs/hide-tabs-macos.css
@@ -5,7 +5,7 @@
 /*
  * This style will hide the tab bar. For MacOS
  *
- * Contributor(s): Isaac-Newt, Ivan0xFF, millerdev
+ * Contributor(s): Isaac-Newt, Ivan0xFF, millerdev, AMomchilov
  */
 
 #titlebar {
@@ -17,8 +17,12 @@
   display: block;
   position: absolute;
   visibility: visible;
-  margin-left: 2px;
-  margin-top: 2px;
+  margin-left: 12px;
+  margin-top: 12px;
+}
+
+#TabsToolbar .titlebar-buttonbox.titlebar-color {
+	margin-left: 0px !important;
 }
 
 /*
@@ -26,5 +30,5 @@
  * Only apply this style when not in fullscreen mode.
  */
 #main-window:not([inFullscreen]) #nav-bar{
-  padding: 0px 5px 0px 105px !important;
+  padding: 0px 0px 0px 70px !important;
 }


### PR DESCRIPTION
Here's how [the current styles](https://github.com/Timvde/UserChrome-Tweaks/blob/master/tabs/hide-tabs-macos.css) look in Big Sur:


![Controls were out of place on Big Sur](https://user-images.githubusercontent.com/5703449/100533727-75423380-31d5-11eb-9619-95341efb3c8f.png)

And here's the fixed:

![Fixed for Big Sur](https://user-images.githubusercontent.com/5703449/100533738-8ee37b00-31d5-11eb-8628-460e7ecd67c2.png)

Is it possible to detect MacOS 10.x (so it uses the old style), and only apply this for 11.x (Big Sur)?
